### PR TITLE
chore(variables): remove "Headers" information

### DIFF
--- a/app/assets/javascripts/_custom.js
+++ b/app/assets/javascripts/_custom.js
@@ -1,5 +1,5 @@
 $("a.popup-link").on("click", function () {
-    specs = "left=20,top=20,width=700,height=600,toolbar=0";
+    specs = "left=20,top=20,width=800,height=600,toolbar=0";
     window.open( $(this).attr('href'), "popup", specs);
     return false;
 });

--- a/app/views/help/_pane_liquid_headers.md
+++ b/app/views/help/_pane_liquid_headers.md
@@ -1,3 +1,0 @@
-## Liquid Headers Variable
-
-*Coming Soon*

--- a/app/views/help/_pane_liquid_summary.md
+++ b/app/views/help/_pane_liquid_summary.md
@@ -3,7 +3,6 @@ Scrappr makes use of the Liquid templating library to provide useful
 functionality within your endpoint content.  Such functionality includes:
 
 * **Params** - Access to submitted parameters
-* **Headers** - Access to submitted headers
 * **Fake** - Generated Data (powered by Faker)
 
 

--- a/app/views/help/liquid_variables.html.erb
+++ b/app/views/help/liquid_variables.html.erb
@@ -4,7 +4,6 @@
   <ul class="tabbed-nav nav nav-tabs" role="tablist">
     <li class="active"><a href="#pane-summary">Summary</a></li>
     <li><a href="#pane-params">Params</a></li>
-    <li><a href="#pane-headers">Headers</a></li>
     <li><a href="#pane-fake">Fake</a></li>
   </ul>
 </div>
@@ -21,10 +20,6 @@
     <div class="tab-pane fade" id="pane-fake">
       <br />
       <%= render partial: "pane_liquid_fake" %>
-    </div>
-
-    <div class="tab-pane fade" id="pane-headers">
-      <%= render partial: "pane_liquid_headers" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
As per scrapprio/scrappr.io#25, "Headers" requires quite a bit of work to make functional. 
So, we're removing the placeholders for now.

Closes #58